### PR TITLE
only run blackduck scan on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,10 @@ workflows:
       - blackduck_check:
           daml_sdk_version: "1.1.1"
           context: blackduck
+          filters:
+            branches:
+              only:
+                - master
   build_and_release:
     jobs:
       - daml_test:


### PR DESCRIPTION
Only run blackduck scan once merged to master to avoid multiple in-flight PRs stomping on each other