### PR TITLE
disable notices report generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
             bash <(curl -s https://raw.githubusercontent.com/DACH-NY/security-blackduck/master/synopsys-detect) \
             ci-build digitalasset_ex-bond-issuance master \
             --logging.level.com.synopsys.integration=DEBUG \
-            --detect.notices.report=true \
+            --detect.notices.report=false \
             --detect.report.timeout=1800
       - run:
           command: cp digitalasset_ex_bond_issuance_master_Black_Duck_Notices_Report.txt NOTICE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,12 +167,13 @@ jobs:
             --logging.level.com.synopsys.integration=DEBUG \
             --detect.notices.report=false \
             --detect.report.timeout=1800
-      - run:
-          command: cp digitalasset_ex_bond_issuance_master_Black_Duck_Notices_Report.txt NOTICE
-      - persist_to_workspace:
-          root: .
-          paths:
-            - "NOTICE"
+### Temporarily disabled due to Blackduck issue (see https://github.com/digital-asset/ex-bond-issuance/pull/156)
+#      - run:
+#          command: cp digitalasset_ex_bond_issuance_master_Black_Duck_Notices_Report.txt NOTICE
+#      - persist_to_workspace:
+#          root: .
+#          paths:
+#            - "NOTICE"
 
   github_release:
     executor: docker_buildpack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,6 +204,7 @@ workflows:
             branches:
               only:
                 - master
+                - /blackduck-.*/
   build_and_release:
     jobs:
       - daml_test:


### PR DESCRIPTION
the report generation seems to be generating a bad character in son output, causing scan to crash
as per guidance from blackduck support on the ticket, trying with this disabled