### PR TITLE
Handle symbol in column path

### DIFF
--- a/ui/src/components/Contracts/Contracts.tsx
+++ b/ui/src/components/Contracts/Contracts.tsx
@@ -228,8 +228,17 @@ export default function Contracts({ contracts, columns, actions, dialogs } : Con
   }
 
   function getValue(data : any, path : string) {
-    const split = typeof path === "string" && path !== "" ? path.split(".") : [];
-    return getByPath(data, split);
+    if(path.includes('/')){
+      const [numerator, denominator] = path.split('/').map((piece) => {return getByPath(data, safeSplit(piece.trim())) })
+      return numerator/denominator;
+    }
+    else{
+      return getByPath(data, safeSplit(path));
+    }
+  }
+
+  function safeSplit(path : any): string[]{
+    return typeof path === "string" && path !== "" ? path.split(".") : [];
   }
 
   function paramNameForRow(paramName: string, rowId: string): string {

--- a/ui/src/pages/auctionRequest/AuctionRequest.tsx
+++ b/ui/src/pages/auctionRequest/AuctionRequest.tsx
@@ -32,7 +32,7 @@ export default function Report() {
           name: "Accept",
           handle: doAccept,
           paramName: "Auction name",
-          shouldDisplay: () => true, //(c) => c.payload.xxxx === standardizePartyId(parties, party),
+          shouldDisplay: () => true,
           items:[],
           values:[]}
       ]}

--- a/ui/src/pages/csdRedemption/CsdRedemption.tsx
+++ b/ui/src/pages/csdRedemption/CsdRedemption.tsx
@@ -27,7 +27,7 @@ export default function Report() {
       {
         name: "Accept",
         handle: doAccept,
-        shouldDisplay: () => true, //(c) => c.payload.verifier === standardizePartyId(parties, party),
+        shouldDisplay: () => true,
         paramName: "",
         items:[],
         values:[]

--- a/ui/src/pages/issuanceReqsCsd/IssuanceReqsCsd.tsx
+++ b/ui/src/pages/issuanceReqsCsd/IssuanceReqsCsd.tsx
@@ -34,16 +34,5 @@ export default function Report() {
       }
     ]}
     dialogs={[]}
-    // actions={[
-    //   {
-    //     name: "Confirm",
-    //     handle: confirm,
-    //     shouldDisplay: (c) => c.payload.standardRegistry === standardizePartyId(parties, party),
-    //     items: [],
-    //     values: [],
-    //     paramName: "",
-    //   }
-    // ]}
-
   />);
 }

--- a/ui/src/pages/pendingSettlementsForBanks/PendingSettlementsForBanks.tsx
+++ b/ui/src/pages/pendingSettlementsForBanks/PendingSettlementsForBanks.tsx
@@ -27,7 +27,7 @@ export default function Report() {
     {
       name: "Settle",
       handle: doSettle,
-      shouldDisplay: () => true, //(c) => c.payload.verifier === standardizePartyId(parties, party),
+      shouldDisplay: () => true,
       paramName: "",
       items:[],
       values:[]


### PR DESCRIPTION
In the columns object, the path is a string. This pr enables that to be parsed out when containing a '/' symbol separating two valid sub-paths.