### PR TITLE
Add codegen target to yarn.lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ $(JS_CODEGEN_ARTIFACT): $(MODELS_DAR) $(FINLIB_DAR)
 
 UI_INSTALL_ARTIFACT=ui/node_modules
 
-ui/yarn.lock: ui/package.json
+ui/yarn.lock: ui/package.json $(JS_CODEGEN_ARTIFACT)
 	cd ui && yarn install
 
 $(UI_INSTALL_ARTIFACT): ui/package.json ui/yarn.lock $(JS_CODEGEN_ARTIFACT)


### PR DESCRIPTION
On a local machine it is possible for the yarn.lock file to be older than package.json, in this case we fix things so the codegen rule is fired. This is not captured in ci because the git checkout timestamps files uniformly.